### PR TITLE
refactor: decouple visual test execution from action status control

### DIFF
--- a/actions/javascript/visual-tests/action.yml
+++ b/actions/javascript/visual-tests/action.yml
@@ -28,4 +28,7 @@ runs:
     - uses: chromaui/action@v13
       with:
         projectToken: ${{ inputs.projectToken }}
-        exitZeroOnChanges: false # Fail workflow if changes are found
+        # This action is just responsible for kicking off the tests
+        # Chromatic will then trigger the UI Tests action which is responsible for
+        # either pass or fail based on a Chromatic review
+        exitZeroOnChanges: true


### PR DESCRIPTION
Previously, this action would fail whenever a PR results in any component visual changes. It would then need to be re-run after the changes are accepted in Chromatic.

This PR updates the visual-tests action, so it is only responsible for kicking off the visual tests. A separate "UI Tests" action built by Chromatic will then pass or fail based on the results of a Chromatic review.