### PR TITLE
feat: adds support for private registry installs

### DIFF
--- a/actions/javascript/library/publish/action.yml
+++ b/actions/javascript/library/publish/action.yml
@@ -34,25 +34,8 @@ runs:
       # quality-gate steps here.
       uses: 24dlong/github-actions-library/actions/javascript/quality-gate@v2
 
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        aws-region: ${{ inputs.AWS_REGION }}
-        role-to-assume: ${{ inputs.AWS_ROLE_TO_ASSUME }}
-
-    - name: Generate Token
-      run: |
-        echo "CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token \
-        --domain ${{ inputs.AWS_CODE_ARTIFACT_DOMAIN }} \
-        --domain-owner ${{ inputs.AWS_ACCOUNT_ID }} \
-        --query authorizationToken \
-        --output text)" >> $GITHUB_ENV
-      shell: bash
-
     - name: Release
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ env.CODEARTIFACT_AUTH_TOKEN }}
-        NPM_CONFIG_REGISTRY: "https://${{ inputs.AWS_CODE_ARTIFACT_DOMAIN }}-${{ inputs.AWS_ACCOUNT_ID }}.d.codeartifact.${{ inputs.AWS_REGION }}.amazonaws.com/npm/${{ inputs.AWS_CODE_ARTIFACT_REPOSITORY }}/"
       run: make publish
       shell: bash

--- a/actions/javascript/quality-gate/action.yml
+++ b/actions/javascript/quality-gate/action.yml
@@ -1,4 +1,26 @@
+name: Quality Gate
 description: To ensure code quality, runs lint, test, and build steps for a javascript repository managed with pnpm.
+
+inputs:
+  AWS_ACCOUNT_ID:
+    description: AWS Account ID hosting CodeArtifact
+    required: true
+  AWS_REGION:
+    description: AWS region hosting CodeArtifact
+    required: true
+  AWS_ROLE_TO_ASSUME:
+    description: AWS role to assume for CodeArtifact repository access
+    required: true
+  AWS_CODE_ARTIFACT_DOMAIN:
+    description: AWS CodeArtifact domain
+    required: true
+  AWS_CODE_ARTIFACT_REPOSITORY:
+    description: AWS CodeArtifact repository
+    required: true
+  REGISTRY_NAMESPACE:
+    description: Namespace to use for registry authentication.
+    required: true
+
 runs:
   using: composite
   steps:
@@ -19,7 +41,18 @@ runs:
           node-version-file: .nvmrc
           cache: 'pnpm'
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ inputs.AWS_REGION }}
+          role-to-assume: ${{ inputs.AWS_ROLE_TO_ASSUME }}
+
       - name: Install Dependencies
+        env:
+            AWS_CODE_ARTIFACT_DOMAIN: ${{ inputs.AWS_CODE_ARTIFACT_DOMAIN }}
+            AWS_ACCOUNT_ID: ${{ inputs.AWS_ACCOUNT_ID }}
+            AWS_CODE_ARTIFACT_REPOSITORY: ${{ inputs.AWS_CODE_ARTIFACT_REPOSITORY }}
+            REGISTRY_NAMESPACE: ${{ inputs.REGISTRY_NAMESPACE }}
         run: make install
         shell: bash
 


### PR DESCRIPTION
BREAKING CHANGE: to standardize to one registry auth process, both the publish command and the install command should now include private registry authentication built in