### PR TITLE
build(publish): ensure breaking changes result in major version bumps

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -2,6 +2,7 @@
 commitizen:
   customize:
     bump_map:
+      BREAKING CHANGE: MAJOR
       build: PATCH
       chore: PATCH
       docs: PATCH
@@ -11,7 +12,7 @@ commitizen:
       refactor: PATCH
       style: PATCH
       test: PATCH
-    bump_pattern: ^(feat|fix|perf|refactor|chore|style|build|docs|test)
+    bump_pattern: ^(BREAKING CHANGE|feat|fix|perf|refactor|chore|style|build|docs|test)
   name: cz_customize
   tag_format: $version
   update_changelog_on_bump: true


### PR DESCRIPTION
BREAKING CHANGE: Previous version included a breaking change. To standardize to one registry auth process, the publish command has been migrated to use a registry-auth make command as well